### PR TITLE
docs: update README.md to specify the Docker image name for version inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,8 @@ This project uses a global version stored in the `VERSION` file located in the r
 After building the image, you can verify the version embedded in the image by running:
 
 ```bash
-docker inspect <image_name> | grep '"version"'
+docker inspect lazyvim | grep '"version"'
 ```
-
-Replace `<image_name>` with the name of your Docker image.
 
 ---
 


### PR DESCRIPTION
This pull request updates the `README.md` file to simplify the example command for verifying the version of a Docker image. 

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-L40): Replaced the placeholder `<image_name>` in the example command with the specific image name `lazyvim` and removed the accompanying explanation about replacing the placeholder.