### PR TITLE
feat: add health check command and improve diagnostics in health-check script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ clean: ## Clean up unused Docker resources
 	@docker volume prune -f
 	@echo "$(GREEN)Cleanup completed$(NC)"
 
+health: ## Run comprehensive health diagnostics
+	@echo "$(BLUE)Running LazyVim environment health check...$(NC)"
+	@./scripts/health-check.sh
+
 status: ## Show container status
 	@echo "$(BLUE)Container Status:$(NC)"
 	@CONTAINER_STATE=$$(docker inspect $(CONTAINER_NAME) 2>/dev/null | grep '"Status"' | cut -d'"' -f4 || echo "missing"); \

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ lazyvim-docker/
 ├── docs/                   # Documentation
 │   ├── COMMANDS.md         # Complete command reference
 │   └── CHANGELOG.md        # Version history
-├── scripts/                # Internal scripts (use make commands instead)
+├── scripts/                # Internal scripts (always use make commands instead)
 │   ├── build.sh           # Build script
 │   ├── init.sh            # Init script
 │   ├── destroy.sh         # Destroy script
@@ -160,14 +160,9 @@ lazyvim-docker/
 
 ```bash
 make status               # Check container status
+make health               # Run comprehensive diagnostics
 make backup               # Backup configurations
 make clean                # Clean up Docker resources
-```
-
-For detailed diagnostics:
-```bash
-# Internal health check (comprehensive diagnostics)
-./scripts/health-check.sh
 ```
 
 ---

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -13,6 +13,7 @@ This document provides a comprehensive guide to all available commands in the La
 | `make help` | Show all available commands with descriptions | `make help` |
 | `make version` | Show current project version | `make version` |
 | `make status` | Show container and environment status | `make status` |
+| `make health` | Run comprehensive health diagnostics | `make health` |
 
 ### Container Management
 


### PR DESCRIPTION
This pull request introduces a new `make health` command to perform comprehensive health diagnostics for the LazyVim Docker environment. It also refactors the `health-check.sh` script for better clarity and functionality. Documentation updates have been made to reflect the new command and its usage.

### New Feature: Health Diagnostics
* Added a `make health` command to the `Makefile`, which runs the `health-check.sh` script to perform a comprehensive health check of the LazyVim environment.

### Documentation Updates
* Updated `README.md` to include the `make health` command in the list of available commands and removed the direct invocation of `./scripts/health-check.sh` from the examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L121-R121) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R163-L172)
* Added `make health` to the command reference in `docs/COMMANDS.md`.

### Script Enhancements
* Refactored `health-check.sh` to improve container state handling:
  - Replaced redundant checks for container existence and state with a single `docker inspect` command.
  - Improved messaging for different container states (e.g., missing, stopped, running).
  - Adjusted final status messages to provide clearer guidance for next steps based on the container's state.