### PR TITLE
fix: update uninstall command to use remote-uninstall script and clarify messaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,9 +164,9 @@ install-global: ## Install global 'lazy' commands to use from anywhere
 	@echo "$(BLUE)Installing LazyVim Docker global commands...$(NC)"
 	@./scripts/install-global-commands.sh
 
-uninstall:
-	@echo "$(BLUE)Uninstalling LazyVim Docker...$(NC)"
-	@./scripts/uninstall-global-commands.sh
+uninstall: ## Complete uninstall - removes everything (same as curl method)
+	@echo "$(BLUE)Running complete LazyVim Docker uninstall...$(NC)"
+	@./scripts/remote-uninstall.sh
 
 install-remote:
 	@echo "$(BLUE)LazyVim Docker - Remote Installation$(NC)"

--- a/scripts/install-global-commands.sh
+++ b/scripts/install-global-commands.sh
@@ -44,7 +44,7 @@ echo "  lazy status     -> make status"
 echo "  lazy build      -> make build"
 echo "  lazy health     -> make health"
 echo "  lazy help       -> make help"
-echo "  lazy uninstall  -> Complete uninstall"
+echo "  lazy uninstall  -> Complete removal (same as curl method)"
 echo ""
 
 # Check if we're in the correct directory
@@ -101,7 +101,7 @@ lazy() {
         echo "  backup    Backup configurations"
         echo "  version   Show version"
         echo "  configure Reconfigure directories and timezone"
-        echo "  uninstall Remove global commands"
+        echo "  uninstall Complete removal (same as curl method)"
         echo ""
         echo "Examples:"
         echo "  lazy enter     # Enter LazyVim from anywhere"
@@ -118,8 +118,8 @@ lazy() {
             (cd "\$lazyvim_docker_path" && make "\$cmd" "\$@")
             ;;
         uninstall)
-            echo "🗑️  Running uninstaller..."
-            (cd "\$lazyvim_docker_path" && ./scripts/uninstall-global-commands.sh)
+            echo "🗑️  Running complete uninstaller..."
+            (cd "\$lazyvim_docker_path" && ./scripts/remote-uninstall.sh)
             ;;
         *)
             echo "❌ Unknown command: \$cmd"
@@ -190,7 +190,7 @@ lazy() {
         echo "  backup    Backup configurations"
         echo "  version   Show version"
         echo "  configure Reconfigure directories and timezone"
-        echo "  uninstall Remove global commands"
+        echo "  uninstall Complete removal (same as curl method)"
         echo ""
         echo "Examples:"
         echo "  lazy enter     # Enter LazyVim from anywhere"
@@ -207,8 +207,8 @@ lazy() {
             (cd "\$lazyvim_docker_path" && make "\$cmd" "\$@")
             ;;
         uninstall)
-            echo "🗑️  Running uninstaller..."
-            (cd "\$lazyvim_docker_path" && ./scripts/uninstall-global-commands.sh)
+            echo "🗑️  Running complete uninstaller..."
+            (cd "\$lazyvim_docker_path" && ./scripts/remote-uninstall.sh)
             ;;
         *)
             echo "❌ Unknown command: \$cmd"


### PR DESCRIPTION
This pull request updates the uninstall process for LazyVim Docker to ensure a more comprehensive removal, aligning it with the behavior of the curl-based installation method. The changes primarily focus on improving clarity in messaging and replacing the uninstallation script with a more thorough alternative.

### Updates to the uninstall process:

* **Makefile**: The `uninstall` target now explicitly states it performs a "Complete uninstall" and uses the `remote-uninstall.sh` script instead of the previous `uninstall-global-commands.sh` script.
* **`scripts/install-global-commands.sh`**:
  - Updated the description of the `lazy uninstall` command to clarify that it performs a "Complete removal (same as curl method)." [[1]](diffhunk://#diff-6755bcf64b612f226a75461973ccbb6bd1ec9a7ed028651bd6698be9c448939eL47-R47) [[2]](diffhunk://#diff-6755bcf64b612f226a75461973ccbb6bd1ec9a7ed028651bd6698be9c448939eL104-R104) [[3]](diffhunk://#diff-6755bcf64b612f226a75461973ccbb6bd1ec9a7ed028651bd6698be9c448939eL193-R193)
  - Modified the `uninstall` command logic to invoke the `remote-uninstall.sh` script, ensuring a more thorough cleanup process. [[1]](diffhunk://#diff-6755bcf64b612f226a75461973ccbb6bd1ec9a7ed028651bd6698be9c448939eL121-R122) [[2]](diffhunk://#diff-6755bcf64b612f226a75461973ccbb6bd1ec9a7ed028651bd6698be9c448939eL210-R211)