### PR TITLE
doc: update license from MIT to GPLv3 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ lazy uninstall && curl -fsSL https://raw.githubusercontent.com/manghidev/lazyvim
 🌐 [Personal Website](https://manghi.dev)  
 📧 [GitHub Issues](https://github.com/manghidev/lazyvim-docker/issues)
 
-**License:** MIT - See [LICENSE](LICENSE) file
+**License:** GPLv3 - See [LICENSE](LICENSE) file
 
 **Additional Resources:**
 - [LazyVim Docs](https://lazyvim.github.io/) | [Neovim Docs](https://neovim.io/doc/)


### PR DESCRIPTION
This pull request updates the license information in the `README.md` file to reflect a change in the licensing terms.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L414-R414): Changed the license from MIT to GPLv3 in the "License" section.